### PR TITLE
Change required version of vue-i18n and critters

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
 		"postcss": "^8.4.6",
 		"tailwindcss": "^3.0.23",
 		"vue": "^3.2.31",
-		"vue-i18n": "^9.2.0-beta.30",
+		"vue-i18n": "^9.0.0",
 		"vue-router": "^4.0.12"
 	},
 	"devDependencies": {
@@ -47,7 +47,7 @@
 		"@vitejs/plugin-vue": "^2.2.0",
 		"@vue/compiler-sfc": "^3.2.31",
 		"@vue/server-renderer": "^3.2.31",
-		"critters": "^0.0.10",
+		"critters": "^0.0.16",
 		"https-localhost": "^4.7.1",
 		"typescript": "^4.5.5",
 		"unplugin-auto-import": "^0.6.0",


### PR DESCRIPTION
When runnig npm install, I had compatibility issues between:

## Critters

- critters@"^0.0.10" and critters@"^0.0.16" from vite-ssg@0.17.10 

Solution: upgrade version of critters to 0.0.16


## Vue-18n
- vue-i18n@"^9.2.0-beta.30" and vue-i18n@"^9.0.0" from @intlify/vite-plugin-vue-i18n@3.3.0

Solution: downgrade version of vue-i18n to 9.0.0


---
After these two version changes, npm installed dependencies successfully.